### PR TITLE
"이미 접속 중인 계정입니다." 제거

### DIFF
--- a/Server/lib/Game/kkutu.js
+++ b/Server/lib/Game/kkutu.js
@@ -562,12 +562,12 @@ exports.Client = function (socket, profile, sid) {
                                             result: 550,
                                             black: result
                                         });
-                                    } else if (Cluster.isMaster && $user.server) {
+                                    }/* else if (Cluster.isMaster && $user.server) {
                                         R.go({
                                             result: 409,
                                             black: $user.server
                                         });
-                                    } else if (exports.NIGHT && my.isAjae === false) {
+                                    }*/ else if (exports.NIGHT && my.isAjae === false) {
                                         R.go({
                                             result: 440
                                         });


### PR DESCRIPTION
간혹 끄투 서버가 유저가 나간 사실을 발견하지 못하고 세션을 계속 남겨두어 발생하는 오류가 발생합니다.
직접 테스트해본 결과 기존 이미 있는 계정과 새로 들어온 계정 둘다 연결이 끊어지기 때문에, 사실 새로 들어온 계정의 연결을 끊을 필요가 전혀 없습니다. 또한 삭제하여도 잘 작동하는 사실을 확인하였습니다.
검토 후 적용 부탁드립니다.